### PR TITLE
Hold left/right to turn left/right

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,8 +1,16 @@
 use crate::sequence::{Sequence, Turn};
 use cgmath::{prelude::*, vec2};
 
+const RADIUS: f32 = 0.3;
+const KEY_LEFT : u32 = 37;
+const KEY_RIGHT : u32 = 39;
+
 pub struct Scene {
     pub worm: Sequence,
+    press_left: bool,
+    press_right: bool,
+    next_turn: Turn,
+    last_turn: Turn,
 }
 
 impl Scene {
@@ -15,25 +23,60 @@ impl Scene {
         sequence.head_forward(0.6);
         sequence.turn_to(Turn::Straight);
         sequence.head_forward(0.2);
-        sequence.turn_to(Turn::Left { radius: 0.3 });
+        let last_turn = Turn::Left { radius: 0.3 };
+        sequence.turn_to(last_turn);
 
-        Scene { worm: sequence }
+        Scene {
+            worm: sequence,
+            press_left: false,
+            press_right: false,
+            last_turn,
+            next_turn: last_turn,
+        }
     }
 
-    pub fn turn_straight(&mut self) {
-        self.worm.turn_to(Turn::Straight);
-    }
+    pub fn key_event(&mut self, code: u32, depressed: bool) -> bool {
+        const LEFT : Turn = Turn::Left { radius: RADIUS };
+        const RIGHT : Turn = Turn::Right { radius: RADIUS };
+        const STRAIGHT : Turn = Turn::Straight;
 
-    pub fn turn_left(&mut self) {
-        self.worm.turn_to(Turn::Left { radius: 0.3 });
-    }
+        let handled = match code {
+            KEY_LEFT => {
+                self.press_left = depressed;
 
-    pub fn turn_right(&mut self) {
-        self.worm.turn_to(Turn::Right { radius: 0.3 });
+                self.next_turn = match depressed {
+                    true => LEFT,
+                    false if self.press_right => RIGHT,
+                    _ => STRAIGHT,
+                };
+
+                true
+            }
+            KEY_RIGHT => {
+                self.press_right = depressed;
+
+                self.next_turn = match depressed {
+                    true => RIGHT,
+                    false if self.press_left => LEFT,
+                    _ => STRAIGHT,
+                };
+
+                true
+            }
+            _ => false,
+        };
+
+        handled
     }
 
     pub fn update(&mut self) {
         const SPEED: f32 = 0.02;
+
+        if self.next_turn != self.last_turn {
+            self.worm.turn_to(self.next_turn);
+            self.last_turn = self.next_turn;
+        }
+
         self.worm.head_forward(SPEED);
         self.worm.tail_forward(SPEED);
     }

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -2,6 +2,7 @@ use crate::segment::Segment;
 use cgmath::{prelude::*, vec2, Vector2};
 use std::collections::VecDeque;
 
+#[derive(PartialEq, Clone, Copy)]
 pub enum Turn {
     Left { radius: f32 },
     Straight,


### PR DESCRIPTION
The complicating factor is holding both keys and letting go of one.

This is the second attempt. The first was to resolve the turn logic in update, but it's equally ifs-and-buttsy (iffy and butty?). I wonder if there is a way with no code duplication, no added abstractions and better readability.

Regardless, I like the separation of logic into Scene.

It might be better to move the "last_turn" logic into Sequence (it wouldn't need to store a field) and just call it every update.
