### PR TITLE
Head forward takes a turn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod renderer;
 mod scene;
 mod segment;
 mod sequence;
+mod turn;
 mod webgl;
 use crate::scene::Scene;
 use std::cell::RefCell;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,4 +1,5 @@
-use crate::sequence::{Sequence, Turn};
+use crate::sequence::Sequence;
+use crate::turn::Turn;
 use cgmath::{prelude::*, vec2};
 
 const KEY_LEFT : u32 = 37;
@@ -8,27 +9,20 @@ pub struct Scene {
     pub worm: Sequence,
     press_left: bool,
     press_right: bool,
-    last_turn: Turn,
 }
 
 impl Scene {
     pub fn new() -> Scene {
         let mut sequence = Sequence::new(vec2(-0.7, 0.), vec2(2., 1.).normalize(), Turn::Straight);
-        sequence.head_forward(0.4);
-        sequence.turn_to(Turn::Right { radius: 0.3 });
-        sequence.head_forward(0.3);
-        sequence.turn_to(Turn::Left { radius: 0.3 });
-        sequence.head_forward(0.6);
-        sequence.turn_to(Turn::Straight);
-        sequence.head_forward(0.2);
-        let last_turn = Turn::Left { radius: 0.3 };
-        sequence.turn_to(last_turn);
+        sequence.head_forward(0.4, Turn::Straight);
+        sequence.head_forward(0.3, Turn::Right { radius: 0.3 });
+        sequence.head_forward(0.6, Turn::Left { radius: 0.3 });
+        sequence.head_forward(0.2, Turn::Straight);
 
         Scene {
             worm: sequence,
             press_left: false,
             press_right: false,
-            last_turn,
         }
     }
 
@@ -46,18 +40,13 @@ impl Scene {
         const SPEED: f32 = 0.02;
         const RADIUS: f32 = 0.3;
 
-        let next_turn = match (self.press_left, self.press_right) {
+        let turn = match (self.press_left, self.press_right) {
             (true, false) => Turn::Left { radius: RADIUS },
             (false, true) => Turn::Right { radius: RADIUS },
             _ => Turn::Straight,
         };
 
-        if next_turn != self.last_turn {
-            self.worm.turn_to(next_turn);
-            self.last_turn = next_turn;
-        }
-
-        self.worm.head_forward(SPEED);
+        self.worm.head_forward(SPEED, turn);
         self.worm.tail_forward(SPEED);
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,8 +1,14 @@
 use crate::sequence::{Sequence, Turn};
 use cgmath::{prelude::*, vec2};
 
+const KEY_LEFT : u32 = 37;
+const KEY_RIGHT : u32 = 39;
+
 pub struct Scene {
     pub worm: Sequence,
+    press_left: bool,
+    press_right: bool,
+    last_turn: Turn,
 }
 
 impl Scene {
@@ -15,25 +21,42 @@ impl Scene {
         sequence.head_forward(0.6);
         sequence.turn_to(Turn::Straight);
         sequence.head_forward(0.2);
-        sequence.turn_to(Turn::Left { radius: 0.3 });
+        let last_turn = Turn::Left { radius: 0.3 };
+        sequence.turn_to(last_turn);
 
-        Scene { worm: sequence }
+        Scene {
+            worm: sequence,
+            press_left: false,
+            press_right: false,
+            last_turn,
+        }
     }
 
-    pub fn turn_straight(&mut self) {
-        self.worm.turn_to(Turn::Straight);
-    }
+    pub fn key_event(&mut self, code: u32, depressed: bool) -> bool {
+        let handled = match code {
+            KEY_LEFT => { self.press_left = depressed; true }
+            KEY_RIGHT => { self.press_right = depressed; true }
+            _ => false,
+        };
 
-    pub fn turn_left(&mut self) {
-        self.worm.turn_to(Turn::Left { radius: 0.3 });
-    }
-
-    pub fn turn_right(&mut self) {
-        self.worm.turn_to(Turn::Right { radius: 0.3 });
+        handled
     }
 
     pub fn update(&mut self) {
         const SPEED: f32 = 0.02;
+        const RADIUS: f32 = 0.3;
+
+        let next_turn = match (self.press_left, self.press_right) {
+            (true, false) => Turn::Left { radius: RADIUS },
+            (false, true) => Turn::Right { radius: RADIUS },
+            _ => Turn::Straight,
+        };
+
+        if next_turn != self.last_turn {
+            self.worm.turn_to(next_turn);
+            self.last_turn = next_turn;
+        }
+
         self.worm.head_forward(SPEED);
         self.worm.tail_forward(SPEED);
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,4 +1,5 @@
 use cgmath::{vec2, Vector2};
+use crate::turn::Turn;
 
 const WIDTH: f32 = 0.1;
 const HALF_WIDTH: f32 = WIDTH / 2.0;
@@ -144,6 +145,19 @@ impl Segment {
                     *start_ang += *ang_dir * sub_len / *r;
                     *len -= sub_len;
                     None
+                }
+            }
+        }
+    }
+
+    pub fn turn(&self) -> Turn {
+        match *self {
+            Segment::Line { .. } => { Turn::Straight }
+            Segment::Arc { r, ang_dir, ..  } => {
+                if ang_dir < 0.0 {
+                    Turn::Right { radius: r }
+                } else {
+                    Turn::Left { radius: r }
                 }
             }
         }

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -29,23 +29,15 @@ fn arc(
 
 impl Sequence {
     pub fn new(pos: Vector2<f32>, dir: Vector2<f32>, turn: Turn) -> Sequence {
-        Sequence {
-            segments: vec![match turn {
-                Turn::Left { radius } => arc(pos, dir, radius, 0., false),
-                Turn::Straight => Segment::Line {
-                    start: pos,
-                    dir,
-                    len: 0.,
-                },
-                Turn::Right { radius } => arc(pos, dir, radius, 0., true),
-            }]
-            .into(),
-        }
+        let mut sequence = Sequence { segments: Vec::new().into() };
+        sequence.new_segment(pos, dir, turn);
+        sequence
     }
 
     pub fn head_forward(&mut self, len: f32, turn: Turn) {
         if turn != self.segments.back().unwrap().turn() {
-            self.new_segment(turn);
+            let (pos, dir) = self.segments.back().unwrap().ending();
+            self.new_segment(pos, dir, turn);
         }
 
         self.segments.back_mut().unwrap().head_forward(len);
@@ -61,9 +53,7 @@ impl Sequence {
         }
     }
 
-    fn new_segment(&mut self, turn: Turn) {
-        let (pos, dir) = self.segments.back().unwrap().ending();
-
+    fn new_segment(&mut self, pos: Vector2<f32>, dir: Vector2<f32>, turn: Turn) {
         self.segments.push_back(match turn {
             Turn::Left { radius } => arc(pos, dir, radius, 0., false),
             Turn::Straight => Segment::Line {

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,13 +1,7 @@
 use crate::segment::Segment;
+use crate::turn::Turn;
 use cgmath::{prelude::*, vec2, Vector2};
 use std::collections::VecDeque;
-
-#[derive(PartialEq, Clone, Copy)]
-pub enum Turn {
-    Left { radius: f32 },
-    Straight,
-    Right { radius: f32 },
-}
 
 pub struct Sequence {
     segments: VecDeque<Segment>,
@@ -49,7 +43,11 @@ impl Sequence {
         }
     }
 
-    pub fn head_forward(&mut self, len: f32) {
+    pub fn head_forward(&mut self, len: f32, turn: Turn) {
+        if turn != self.segments.back().unwrap().turn() {
+            self.new_segment(turn);
+        }
+
         self.segments.back_mut().unwrap().head_forward(len);
     }
 
@@ -63,7 +61,7 @@ impl Sequence {
         }
     }
 
-    pub fn turn_to(&mut self, turn: Turn) {
+    fn new_segment(&mut self, turn: Turn) {
         let (pos, dir) = self.segments.back().unwrap().ending();
 
         self.segments.push_back(match turn {

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -2,6 +2,7 @@ use crate::segment::Segment;
 use cgmath::{prelude::*, vec2, Vector2};
 use std::collections::VecDeque;
 
+#[derive(PartialEq, Clone, Copy)]
 pub enum Turn {
     Left { radius: f32 },
     Straight,

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -1,0 +1,7 @@
+#[derive(PartialEq, Clone, Copy)]
+pub enum Turn {
+    Left { radius: f32 },
+    Straight,
+    Right { radius: f32 },
+}
+


### PR DESCRIPTION
This PR is branched off of #7, so that should be merged first.

Each call to turn_to created a new segment, so callers had to be careful. Instead, pass the current turning to head_forward and let sequence figure out if a new segment is needed.

Move Turn out to a new file since it's being used everywhere.

﻿- Hold left/right to turn left/right
- Head forward takes a turn
